### PR TITLE
Fix typo in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,5 +11,5 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
-  - REAMD.md
+  - README.md
   - CONTRIBUTING.md


### PR DESCRIPTION
I'm assuming this was meant to exclude the `README.md` file from being included in the generated Jekyll site. Should `package.json` also be excluded? I can tack that on if that's supposed to be excluded, too.